### PR TITLE
fix: promote golang.org/x/term to direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.24.0
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/term v0.35.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
-	golang.org/x/term v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Changes
- Ran `go mod tidy` to promote `golang.org/x/term` from an indirect to a direct dependency in `go.mod`

## Root Cause
The new `go mod tidy` drift check added in `c8a8e96` immediately caught that `golang.org/x/term` is directly imported by the library but was incorrectly listed as `// indirect` in `go.mod`. CI failed on the first push after the check was introduced.

## Version Bump
- Type: Patch (no behavior change, dependency metadata fix only)
- Note: No version bump included — this is a metadata-only fix to `go.mod`/`go.sum` with no code changes