### PR TITLE
ci: Add version consistency gate + bump to v0.3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,33 @@ jobs:
           version: latest
           args: --timeout=5m
 
+  version-consistency:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check version consistency across constants.go, CHANGELOG.md, and README.md
+        run: |
+          CONST_VERSION=$(grep -oP 'Version = "\K[^"]+' pkg/costco/constants.go)
+          CHANGELOG_VERSION=$(grep -m1 -oP '## \[\K[^\]]+' CHANGELOG.md)
+          README_VERSION=$(grep -oP 'version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1)
+
+          echo "constants.go : $CONST_VERSION"
+          echo "CHANGELOG.md : $CHANGELOG_VERSION"
+          echo "README.md    : $README_VERSION"
+
+          if [ "$CONST_VERSION" != "$CHANGELOG_VERSION" ] || [ "$CONST_VERSION" != "$README_VERSION" ]; then
+            echo ""
+            echo "Version mismatch! All three must agree."
+            echo "Update constants.go, CHANGELOG.md, and README.md to the same version before merging."
+            exit 1
+          fi
+
+          echo "All versions consistent: $CONST_VERSION"
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2026-04-23
+
+### Fixed
+- **Version Drift**: Sync `constants.go` and `README.md` badge to `0.3.7` — both were missed during the `v0.3.6` re-tag and still reported `0.3.5`.
+- **go.mod**: Promoted `golang.org/x/term` from indirect to direct dependency.
+
+### Added
+- **CI Version Gate**: New `version-consistency` CI job that fails if `constants.go`, `CHANGELOG.md`, and the `README.md` badge don't all report the same version, preventing this class of drift in the future.
+
+[0.3.7]: https://github.com/eshaffer321/costco-go/compare/v0.3.6...v0.3.7
+
 ## [0.3.6] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Costco Go Client
 
-[![Version](https://img.shields.io/badge/version-0.3.5-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.5)
+[![Version](https://img.shields.io/badge/version-0.3.7-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.7)
 
 A Go client library and CLI for accessing Costco order history and receipt data via their GraphQL API.
 

--- a/pkg/costco/constants.go
+++ b/pkg/costco/constants.go
@@ -2,7 +2,7 @@ package costco
 
 // Library Version
 const (
-	Version = "0.3.5"
+	Version = "0.3.7"
 )
 
 // API Endpoints


### PR DESCRIPTION
## Changes

### ci: Version consistency gate
Adds a new `version-consistency` CI job that fails if the version in `pkg/costco/constants.go`, the latest entry in `CHANGELOG.md`, and the `README.md` badge don't all agree. This prevents the class of mistake (seen in v0.3.6) where only one or two of the three files gets updated.

### fix: Bump to v0.3.7
Corrects the version drift left by v0.3.6 — `constants.go` and the README badge were never updated from `0.3.5`. Brings all three sources in sync at `0.3.7`.

## Red-Green Cycle
This PR is structured so the gate commit lands first and fails CI (RED — `constants.go`=0.3.5, `README`=0.3.5, `CHANGELOG`=0.3.6 all disagree), then the version bump commit makes it pass (GREEN).

## Version Bump
- Type: Patch (0.3.6 → 0.3.7)
- Reason: Metadata-only fix to sync version constant and README badge that were missed in the v0.3.6 release

## Checklist
- [x] Version constant updated in constants.go
- [x] CHANGELOG.md updated
- [x] README.md badge updated
- [x] All tests passing
- [x] Code formatted with gofmt