### PR TITLE
feat: Add token-import command for browser-based auth bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-costco-cli
+/costco-cli
 *.exe
 *.dll
 *.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-04-23
+
+### Added
+- **`costco-cli -cmd import-token`**: New CLI command to bootstrap authentication by pasting the JSON response from the Costco token endpoint. Eliminates the need to manually edit `~/.costco/tokens.json`. See README for instructions.
+- **`ImportTokenResponse()`**: New exported library function that converts a `TokenResponse` into `StoredTokens`, parsing the JWT expiry and calculating refresh token expiry from `refresh_token_expires_in`.
+
+[0.3.8]: https://github.com/eshaffer321/costco-go/compare/v0.3.7...v0.3.8
+
 ## [0.3.7] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Costco Go Client
 
-[![Version](https://img.shields.io/badge/version-0.3.7-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.7)
+[![Version](https://img.shields.io/badge/version-0.3.8-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.8)
 
 A Go client library and CLI for accessing Costco order history and receipt data via their GraphQL API.
 

--- a/README.md
+++ b/README.md
@@ -176,16 +176,42 @@ Every log message includes a `client=costco` attribute for easy identification i
 ### Build the CLI
 
 ```bash
-go build -o costco-cli cmd/costco-cli/main.go
+go build -o costco-cli ./cmd/costco-cli
 ```
 
-### Set credentials via environment variables
+### Authentication Setup
+
+Authentication requires a valid token from Costco's OAuth2 endpoint. Tokens are stored in `~/.costco/tokens.json` and automatically refreshed (refresh tokens are valid for ~90 days).
+
+**Step 1 — Store your email and warehouse number:**
 
 ```bash
-export COSTCO_EMAIL="your-email@example.com"
-export COSTCO_PASSWORD="your-password"
-export COSTCO_WAREHOUSE="847"  # Optional, defaults to 847
+./costco-cli -cmd setup
 ```
+
+**Step 2 — Import a token from your browser:**
+
+```bash
+./costco-cli -cmd import-token
+```
+
+Then paste the JSON response body when prompted. To get it:
+
+1. Log in to [costco.com](https://www.costco.com) in your browser
+2. Open DevTools → Network tab → filter by **Fetch/XHR**
+3. Search for **"token"** and select the request to the token endpoint
+4. Click the **Response** tab and copy the full JSON body
+5. Paste it into the terminal and press **Ctrl+D**
+
+The command will confirm the token was saved and show the expiry times:
+
+```
+✓ Tokens saved to ~/.costco/tokens.json
+  ID token valid until:      2026-04-23 14:53:00 MDT
+  Refresh token valid until: 2026-07-22 14:38:00 MDT
+```
+
+Once tokens are saved, all CLI commands work without any further authentication steps. When the refresh token expires (~90 days), repeat Step 2.
 
 ### Get online orders
 
@@ -228,13 +254,10 @@ export COSTCO_WAREHOUSE="847"  # Optional, defaults to 847
 
 ### CLI Flags
 
-- `-email`: Costco account email (overrides COSTCO_EMAIL env var)
-- `-password`: Costco account password (overrides COSTCO_PASSWORD env var)
-- `-warehouse`: Warehouse number (overrides COSTCO_WAREHOUSE env var, default: 847)
-- `-cmd`: Command to run: `orders`, `receipts`, or `receipt-detail`
+- `-cmd`: Command to run: `setup`, `import-token`, `info`, `orders`, `receipts`, `receipt-detail`
 - `-start`: Start date in YYYY-MM-DD format
 - `-end`: End date in YYYY-MM-DD format
-- `-barcode`: Receipt barcode (required for receipt-detail command)
+- `-barcode`: Receipt barcode (required for `receipt-detail`)
 - `-page`: Page number for orders (default: 1)
 - `-size`: Page size for orders (default: 10)
 - `-json`: Output results as JSON
@@ -254,10 +277,11 @@ The client uses Costco's OAuth2 authentication flow and GraphQL API:
 - **Auth header**: `costco-x-authorization: Bearer {id_token}`
 
 The client handles:
-- Initial authentication with email/password
-- Automatic token refresh before expiry
+- Automatic token refresh before expiry (tokens stored in `~/.costco/tokens.json`)
 - Thread-safe token management
 - GraphQL query construction and response parsing
+
+Bootstrap tokens using `costco-cli -cmd import-token` — see [Authentication Setup](#authentication-setup) above.
 
 ## Data Structures
 

--- a/cmd/costco-cli/import.go
+++ b/cmd/costco-cli/import.go
@@ -26,7 +26,7 @@ func importTokens() error {
 	}
 
 	var resp costco.TokenResponse
-	if err := json.Unmarshal(data, &resp); err != nil {
+	if err = json.Unmarshal(data, &resp); err != nil {
 		return fmt.Errorf("parsing JSON: %w\n\nMake sure you copied the Response body (not the Headers)", err)
 	}
 
@@ -35,7 +35,7 @@ func importTokens() error {
 		return err
 	}
 
-	if err := costco.SaveTokens(tokens); err != nil {
+	if err = costco.SaveTokens(tokens); err != nil {
 		return fmt.Errorf("saving tokens: %w", err)
 	}
 

--- a/cmd/costco-cli/import.go
+++ b/cmd/costco-cli/import.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eshaffer321/costco-go/pkg/costco"
+)
+
+func importTokens() error {
+	fmt.Println("Paste the JSON response from the Costco token endpoint, then press Ctrl+D:")
+	fmt.Println()
+	fmt.Println("  How to get it:")
+	fmt.Println("  1. Log in to costco.com in your browser")
+	fmt.Println("  2. Open DevTools → Network → filter Fetch/XHR")
+	fmt.Println("  3. Search for 'token' and select the token endpoint request")
+	fmt.Println("  4. Copy the full Response body (JSON)")
+	fmt.Println("  5. Paste it here")
+	fmt.Println()
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	var resp costco.TokenResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("parsing JSON: %w\n\nMake sure you copied the Response body (not the Headers)", err)
+	}
+
+	tokens, err := costco.ImportTokenResponse(&resp)
+	if err != nil {
+		return err
+	}
+
+	if err := costco.SaveTokens(tokens); err != nil {
+		return fmt.Errorf("saving tokens: %w", err)
+	}
+
+	fmt.Println("✓ Tokens saved to ~/.costco/tokens.json")
+	fmt.Printf("  ID token valid until:      %s\n", tokens.TokenExpiry.Format("2006-01-02 15:04:05 MST"))
+	fmt.Printf("  Refresh token valid until: %s\n", tokens.RefreshTokenExpiresAt.Format("2006-01-02 15:04:05 MST"))
+	return nil
+}

--- a/cmd/costco-cli/import.go
+++ b/cmd/costco-cli/import.go
@@ -9,18 +9,18 @@ import (
 	"github.com/eshaffer321/costco-go/pkg/costco"
 )
 
-func importTokens() error {
-	fmt.Println("Paste the JSON response from the Costco token endpoint, then press Ctrl+D:")
-	fmt.Println()
-	fmt.Println("  How to get it:")
-	fmt.Println("  1. Log in to costco.com in your browser")
-	fmt.Println("  2. Open DevTools → Network → filter Fetch/XHR")
-	fmt.Println("  3. Search for 'token' and select the token endpoint request")
-	fmt.Println("  4. Copy the full Response body (JSON)")
-	fmt.Println("  5. Paste it here")
-	fmt.Println()
+func importTokens(in io.Reader, out io.Writer) error {
+	fmt.Fprintln(out, "Paste the JSON response from the Costco token endpoint, then press Ctrl+D:")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  How to get it:")
+	fmt.Fprintln(out, "  1. Log in to costco.com in your browser")
+	fmt.Fprintln(out, "  2. Open DevTools → Network → filter Fetch/XHR")
+	fmt.Fprintln(out, "  3. Search for 'token' and select the token endpoint request")
+	fmt.Fprintln(out, "  4. Copy the full Response body (JSON)")
+	fmt.Fprintln(out, "  5. Paste it here")
+	fmt.Fprintln(out)
 
-	data, err := io.ReadAll(os.Stdin)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return fmt.Errorf("reading input: %w", err)
 	}
@@ -39,8 +39,12 @@ func importTokens() error {
 		return fmt.Errorf("saving tokens: %w", err)
 	}
 
-	fmt.Println("✓ Tokens saved to ~/.costco/tokens.json")
-	fmt.Printf("  ID token valid until:      %s\n", tokens.TokenExpiry.Format("2006-01-02 15:04:05 MST"))
-	fmt.Printf("  Refresh token valid until: %s\n", tokens.RefreshTokenExpiresAt.Format("2006-01-02 15:04:05 MST"))
+	fmt.Fprintln(out, "✓ Tokens saved to ~/.costco/tokens.json")
+	fmt.Fprintf(out, "  ID token valid until:      %s\n", tokens.TokenExpiry.Format("2006-01-02 15:04:05 MST"))
+	fmt.Fprintf(out, "  Refresh token valid until: %s\n", tokens.RefreshTokenExpiresAt.Format("2006-01-02 15:04:05 MST"))
 	return nil
+}
+
+func runImportTokens() error {
+	return importTokens(os.Stdin, os.Stdout)
 }

--- a/cmd/costco-cli/import_test.go
+++ b/cmd/costco-cli/import_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildImportTestJWT(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+	return header + "." + payload + ".fakesignature"
+}
+
+func tokenJSON(t *testing.T, exp int64) string {
+	t.Helper()
+	return fmt.Sprintf(`{"id_token":%q,"refresh_token":"refresh-abc","refresh_token_expires_in":7776000}`,
+		buildImportTestJWT(exp))
+}
+
+func withTempConfig(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("COSTCO_TEST_CONFIG_PATH", filepath.Join(dir, ".costco"))
+}
+
+func TestImportTokens_Success(t *testing.T) {
+	withTempConfig(t)
+
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	in := strings.NewReader(tokenJSON(t, exp))
+	var out bytes.Buffer
+
+	err := importTokens(in, &out)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "✓ Tokens saved")
+	assert.Contains(t, out.String(), "ID token valid until")
+	assert.Contains(t, out.String(), "Refresh token valid until")
+}
+
+func TestImportTokens_InvalidJSON(t *testing.T) {
+	withTempConfig(t)
+
+	in := strings.NewReader("not json at all")
+	var out bytes.Buffer
+
+	err := importTokens(in, &out)
+	assert.ErrorContains(t, err, "parsing JSON")
+}
+
+func TestImportTokens_MissingIDToken(t *testing.T) {
+	withTempConfig(t)
+
+	in := strings.NewReader(`{"refresh_token":"abc","refresh_token_expires_in":7776000}`)
+	var out bytes.Buffer
+
+	err := importTokens(in, &out)
+	assert.ErrorContains(t, err, "id_token")
+}
+
+func TestImportTokens_MissingRefreshToken(t *testing.T) {
+	withTempConfig(t)
+
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	json := fmt.Sprintf(`{"id_token":%q,"refresh_token_expires_in":7776000}`, buildImportTestJWT(exp))
+	in := strings.NewReader(json)
+	var out bytes.Buffer
+
+	err := importTokens(in, &out)
+	assert.ErrorContains(t, err, "refresh_token")
+}
+
+func TestImportTokens_WritesToDisk(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".costco")
+	t.Setenv("COSTCO_TEST_CONFIG_PATH", configDir)
+
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	in := strings.NewReader(tokenJSON(t, exp))
+	var out bytes.Buffer
+
+	require.NoError(t, importTokens(in, &out))
+	_, err := os.Stat(filepath.Join(configDir, "tokens.json"))
+	assert.NoError(t, err, "tokens.json should exist on disk after import")
+}

--- a/cmd/costco-cli/main.go
+++ b/cmd/costco-cli/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	var (
-		command    = flag.String("cmd", "", "Command: setup, info, orders, receipts, receipt-detail")
+		command    = flag.String("cmd", "", "Command: setup, import-token, info, orders, receipts, receipt-detail")
 		startDate  = flag.String("start", "", "Start date (YYYY-MM-DD)")
 		endDate    = flag.String("end", "", "End date (YYYY-MM-DD)")
 		barcode    = flag.String("barcode", "", "Receipt barcode (for receipt-detail)")
@@ -31,6 +31,13 @@ func main() {
 	// Handle setup and info commands first
 	if *command == "setup" {
 		if err := setupCredentials(); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	if *command == "import-token" {
+		if err := importTokens(); err != nil {
 			log.Fatal(err)
 		}
 		return

--- a/cmd/costco-cli/main.go
+++ b/cmd/costco-cli/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	if *command == "import-token" {
-		if err := importTokens(); err != nil {
+		if err := runImportTokens(); err != nil {
 			log.Fatal(err)
 		}
 		return

--- a/pkg/costco/constants.go
+++ b/pkg/costco/constants.go
@@ -2,7 +2,7 @@ package costco
 
 // Library Version
 const (
-	Version = "0.3.7"
+	Version = "0.3.8"
 )
 
 // API Endpoints

--- a/pkg/costco/token_import.go
+++ b/pkg/costco/token_import.go
@@ -1,0 +1,48 @@
+package costco
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ImportTokenResponse converts a raw TokenResponse from the Costco token endpoint
+// into StoredTokens ready to be persisted with SaveTokens.
+//
+// The expected source is the JSON response body from:
+//
+//	POST https://signin.costco.com/.../oauth2/v2.0/token
+//
+// Users can obtain this by logging into costco.com, opening DevTools → Network,
+// filtering by Fetch/XHR, searching "token", and copying the response body.
+func ImportTokenResponse(resp *TokenResponse) (*StoredTokens, error) {
+	if resp.IDToken == "" {
+		return nil, fmt.Errorf("id_token is missing from token response")
+	}
+	if resp.RefreshToken == "" {
+		return nil, fmt.Errorf("refresh_token is missing from token response")
+	}
+
+	return &StoredTokens{
+		IDToken:               resp.IDToken,
+		RefreshToken:          resp.RefreshToken,
+		TokenExpiry:           parseTokenExpiry(resp.IDToken),
+		RefreshTokenExpiresAt: time.Now().Add(time.Duration(resp.RefreshTokenExpiresIn) * time.Second),
+	}, nil
+}
+
+func parseTokenExpiry(tokenString string) time.Time {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return time.Now().Add(15 * time.Minute)
+	}
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
+		if exp, ok := claims["exp"].(float64); ok {
+			return time.Unix(int64(exp), 0)
+		}
+	}
+
+	return time.Now().Add(15 * time.Minute)
+}

--- a/pkg/costco/token_import_test.go
+++ b/pkg/costco/token_import_test.go
@@ -91,3 +91,20 @@ func TestImportTokenResponse_MalformedJWTFallsBackToDefault(t *testing.T) {
 	// Should fall back to a short default expiry, not zero time
 	assert.True(t, tokens.TokenExpiry.After(time.Now()))
 }
+
+func TestImportTokenResponse_JWTWithoutExpFallsBackToDefault(t *testing.T) {
+	// Valid JWT structure but payload has no exp claim
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user123"}`))
+	noExpJWT := header + "." + payload + ".fakesignature"
+
+	resp := &TokenResponse{
+		IDToken:               noExpJWT,
+		RefreshToken:          "my-refresh-token",
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	tokens, err := ImportTokenResponse(resp)
+	require.NoError(t, err)
+	assert.True(t, tokens.TokenExpiry.After(time.Now()))
+}

--- a/pkg/costco/token_import_test.go
+++ b/pkg/costco/token_import_test.go
@@ -1,0 +1,93 @@
+package costco
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestJWT creates a minimal unsigned JWT with the given exp claim.
+// ParseUnverified doesn't check signatures so this is sufficient for tests.
+func buildTestJWT(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+	return header + "." + payload + ".fakesignature"
+}
+
+func TestImportTokenResponse_SetsTokenExpiry(t *testing.T) {
+	exp := time.Now().Add(15 * time.Minute).Unix()
+	resp := &TokenResponse{
+		IDToken:               buildTestJWT(exp),
+		RefreshToken:          "refresh-token-value",
+		RefreshTokenExpiresIn: 7776000, // 90 days
+	}
+
+	tokens, err := ImportTokenResponse(resp)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Unix(exp, 0), tokens.TokenExpiry, time.Second)
+}
+
+func TestImportTokenResponse_SetsRefreshTokenExpiry(t *testing.T) {
+	resp := &TokenResponse{
+		IDToken:               buildTestJWT(time.Now().Add(15 * time.Minute).Unix()),
+		RefreshToken:          "refresh-token-value",
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	before := time.Now()
+	tokens, err := ImportTokenResponse(resp)
+	require.NoError(t, err)
+
+	expectedExpiry := before.Add(7776000 * time.Second)
+	assert.WithinDuration(t, expectedExpiry, tokens.RefreshTokenExpiresAt, 2*time.Second)
+}
+
+func TestImportTokenResponse_CopiesTokenValues(t *testing.T) {
+	resp := &TokenResponse{
+		IDToken:               buildTestJWT(time.Now().Add(15 * time.Minute).Unix()),
+		RefreshToken:          "my-refresh-token",
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	tokens, err := ImportTokenResponse(resp)
+	require.NoError(t, err)
+	assert.Equal(t, resp.IDToken, tokens.IDToken)
+	assert.Equal(t, resp.RefreshToken, tokens.RefreshToken)
+}
+
+func TestImportTokenResponse_MissingIDToken(t *testing.T) {
+	resp := &TokenResponse{
+		RefreshToken:          "my-refresh-token",
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	_, err := ImportTokenResponse(resp)
+	assert.ErrorContains(t, err, "id_token")
+}
+
+func TestImportTokenResponse_MissingRefreshToken(t *testing.T) {
+	resp := &TokenResponse{
+		IDToken:               buildTestJWT(time.Now().Add(15 * time.Minute).Unix()),
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	_, err := ImportTokenResponse(resp)
+	assert.ErrorContains(t, err, "refresh_token")
+}
+
+func TestImportTokenResponse_MalformedJWTFallsBackToDefault(t *testing.T) {
+	resp := &TokenResponse{
+		IDToken:               "not.a.jwt",
+		RefreshToken:          "my-refresh-token",
+		RefreshTokenExpiresIn: 7776000,
+	}
+
+	tokens, err := ImportTokenResponse(resp)
+	require.NoError(t, err)
+	// Should fall back to a short default expiry, not zero time
+	assert.True(t, tokens.TokenExpiry.After(time.Now()))
+}


### PR DESCRIPTION
## Changes

Formalizes the actual bootstrap path for costco-go authentication.

### Problem
The documented setup flow (email + password → automatic auth) relies on the OAuth2 ROPC grant, which is likely broken due to the `AADB2C90055` scope error reported in #12. The real working bootstrap path is to copy the token JSON response from the browser after logging into costco.com.

### Solution
- **`costco-cli -cmd import-token`**: Reads the raw JSON response body from the Costco token endpoint (pasted from browser DevTools) and writes it to `~/.costco/tokens.json`
- **`ImportTokenResponse()`**: New exported library function that handles the conversion — parses JWT expiry from the `id_token`, calculates refresh token expiry from `refresh_token_expires_in`
- **`.gitignore` fix**: The `costco-cli` binary pattern was also matching the `cmd/costco-cli/` source directory, preventing new source files from being committed

### How to get the token from the browser
1. Log in to costco.com
2. DevTools → Network → filter Fetch/XHR → search "token"
3. Select the token endpoint request → copy the Response body (JSON)
4. Run `costco-cli -cmd import-token` and paste

## Version Bump
- Type: Minor (0.3.7 → 0.3.8) — new feature

## Checklist
- [x] Tests written first (RED → GREEN)
- [x] All tests passing
- [x] Version constant, CHANGELOG, README badge all updated