### PR TITLE
fix: add NetDiscounts utility with partial-description fallback (v0.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2026-05-26
+
+### Added
+- **`NetDiscounts(items []ReceiptItem) ([]ReceiptItem, []ReceiptItem)`**: New exported utility function that applies Costco discount line items to their parent items using a three-level matching strategy: (1) exact item-number match, (2) exact description match (case-insensitive), (3) substring/contains match. Returns the netted regular items and any orphaned discounts that could not be matched. Fixes the case where a coupon references a parent by a partial description token (e.g. `/AAA BATTERY`) that does not exactly match the parent's full description (e.g. `AA/AAA BATTERY`).
+
+[0.3.9]: https://github.com/eshaffer321/costco-go/compare/v0.3.8...v0.3.9
+
 ## [0.3.8] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Costco Go Client
 
-[![Version](https://img.shields.io/badge/version-0.3.8-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.8)
+[![Version](https://img.shields.io/badge/version-0.3.9-blue.svg)](https://github.com/eshaffer321/costco-go/releases/tag/v0.3.9)
 
 A Go client library and CLI for accessing Costco order history and receipt data via their GraphQL API.
 

--- a/pkg/costco/constants.go
+++ b/pkg/costco/constants.go
@@ -2,7 +2,7 @@ package costco
 
 // Library Version
 const (
-	Version = "0.3.8"
+	Version = "0.3.9"
 )
 
 // API Endpoints

--- a/pkg/costco/receipts.go
+++ b/pkg/costco/receipts.go
@@ -107,6 +107,72 @@ func (item *ReceiptItem) GetParentItemNumber() string {
 	return strings.TrimSpace(strings.TrimPrefix(item.ItemDescription01, "/"))
 }
 
+// NetDiscounts applies discount line items to their parent items and returns the result.
+//
+// Costco receipts contain discount items whose ItemDescription01 starts with "/".
+// The part after "/" is either an item number (e.g. "/1553261") or a description
+// token (e.g. "/AAA BATTERY"). NetDiscounts matches each discount to its parent
+// using three strategies in order:
+//
+//  1. Exact item-number match
+//  2. Exact description match (case-insensitive)
+//  3. Substring/contains match (case-insensitive) — handles cases like "/AAA BATTERY"
+//     matching a parent described as "AA/AAA BATTERY"
+//
+// Returns:
+//   - netted: regular (non-discount) items with prices adjusted
+//   - orphaned: discount items that could not be matched to any parent
+func NetDiscounts(items []ReceiptItem) (netted []ReceiptItem, orphaned []ReceiptItem) {
+	// Index non-discount items by item number and by upper-cased description.
+	type entry struct {
+		idx int // index into netted slice (built in first pass)
+	}
+	byNumber := make(map[string]*entry)
+	byDesc := make(map[string]*entry)
+
+	for _, item := range items {
+		if !item.IsDiscount() {
+			netted = append(netted, item)
+			e := &entry{idx: len(netted) - 1}
+			byNumber[item.ItemNumber] = e
+			byDesc[strings.ToUpper(strings.TrimSpace(item.ItemDescription01))] = e
+		}
+	}
+
+	// Apply discounts.
+	for _, item := range items {
+		if !item.IsDiscount() {
+			continue
+		}
+		ref := item.GetParentItemNumber()
+		upperRef := strings.ToUpper(ref)
+
+		// 1. Item number match.
+		if e, ok := byNumber[ref]; ok {
+			netted[e.idx].Amount += item.Amount
+			continue
+		}
+		// 2. Exact description match.
+		if e, ok := byDesc[upperRef]; ok {
+			netted[e.idx].Amount += item.Amount
+			continue
+		}
+		// 3. Substring/contains match.
+		matched := false
+		for desc, e := range byDesc {
+			if strings.Contains(desc, upperRef) || strings.Contains(upperRef, desc) {
+				netted[e.idx].Amount += item.Amount
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			orphaned = append(orphaned, item)
+		}
+	}
+	return
+}
+
 // Tender represents payment information on a receipt
 type Tender struct {
 	TenderTypeCode               string  `json:"tenderTypeCode"`

--- a/pkg/costco/receipts_test.go
+++ b/pkg/costco/receipts_test.go
@@ -282,3 +282,84 @@ func TestReceiptItem_ProcessingWorkflow(t *testing.T) {
 	}
 	assert.Equal(t, receipt.SubTotal, total, "Sum of net amounts should equal receipt subtotal")
 }
+
+func TestNetDiscounts(t *testing.T) {
+	t.Run("applies discount via item number match", func(t *testing.T) {
+		items := []ReceiptItem{
+			{ItemNumber: "1553261", ItemDescription01: "GUAC BOWL", Amount: 13.99, Unit: 1},
+			{ItemNumber: "363064", ItemDescription01: "/1553261", Amount: -4.00, Unit: -1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 1)
+		assert.Len(t, orphaned, 0)
+		assert.Equal(t, 9.99, netted[0].Amount)
+		assert.Equal(t, "GUAC BOWL", netted[0].ItemDescription01)
+	})
+
+	t.Run("applies discount via exact description match", func(t *testing.T) {
+		// discount's ItemDescription01 is "/AAA BATTERY" → ref is "AAA BATTERY"
+		// parent item description is exactly "AAA BATTERY"
+		items := []ReceiptItem{
+			{ItemNumber: "379938", ItemDescription01: "AAA BATTERY", Amount: 14.99, Unit: 1},
+			{ItemNumber: "999001", ItemDescription01: "/AAA BATTERY", Amount: -2.50, Unit: -1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 1)
+		assert.Len(t, orphaned, 0)
+		assert.Equal(t, 12.49, netted[0].Amount)
+	})
+
+	t.Run("applies discount via partial description match", func(t *testing.T) {
+		// Real receipts: parent item is "AA/AAA BATTERY" but coupon references "/AAA BATTERY".
+		// Neither item-number nor exact-description lookup succeeds; substring fallback must fire.
+		items := []ReceiptItem{
+			{ItemNumber: "379938", ItemDescription01: "AA/AAA BATTERY", Amount: 14.99, Unit: 1},
+			{ItemNumber: "999001", ItemDescription01: "/AAA BATTERY", Amount: -2.50, Unit: -1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 1, "should have 1 item after netting partial-description-referenced discount")
+		assert.Len(t, orphaned, 0, "discount should be matched, not orphaned")
+		assert.Equal(t, 12.49, netted[0].Amount, "discount should reduce price")
+		assert.Equal(t, "AA/AAA BATTERY", netted[0].ItemDescription01)
+	})
+
+	t.Run("returns orphaned discount when no parent found", func(t *testing.T) {
+		items := []ReceiptItem{
+			{ItemNumber: "111", ItemDescription01: "CHICKEN", Amount: 10.00, Unit: 1},
+			{ItemNumber: "999", ItemDescription01: "/UNKNOWN ITEM", Amount: -2.00, Unit: -1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 1)
+		assert.Len(t, orphaned, 1)
+		assert.Equal(t, 10.00, netted[0].Amount, "unmatched discount must not affect other items")
+		assert.Equal(t, "/UNKNOWN ITEM", orphaned[0].ItemDescription01)
+	})
+
+	t.Run("multiple discounts on same item", func(t *testing.T) {
+		items := []ReceiptItem{
+			{ItemNumber: "1000", ItemDescription01: "TOILET PAPER", Amount: 25.99, Unit: 1},
+			{ItemNumber: "2001", ItemDescription01: "/1000", Amount: -2.00, Unit: -1},
+			{ItemNumber: "2002", ItemDescription01: "/1000", Amount: -1.00, Unit: -1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 1)
+		assert.Len(t, orphaned, 0)
+		assert.Equal(t, 22.99, netted[0].Amount)
+	})
+
+	t.Run("empty input returns empty slices", func(t *testing.T) {
+		netted, orphaned := NetDiscounts(nil)
+		assert.Empty(t, netted)
+		assert.Empty(t, orphaned)
+	})
+
+	t.Run("no discounts returns all items unchanged", func(t *testing.T) {
+		items := []ReceiptItem{
+			{ItemNumber: "1", ItemDescription01: "MILK", Amount: 4.99, Unit: 1},
+			{ItemNumber: "2", ItemDescription01: "EGGS", Amount: 6.99, Unit: 1},
+		}
+		netted, orphaned := NetDiscounts(items)
+		assert.Len(t, netted, 2)
+		assert.Len(t, orphaned, 0)
+	})
+}


### PR DESCRIPTION
## Changes

Adds `NetDiscounts(items []ReceiptItem) ([]ReceiptItem, []ReceiptItem)`, a new exported utility function that handles the full discount-netting workflow so consumers (like itemize) don't have to reimplement it.

### Problem

Costco coupons sometimes reference their parent item by a partial description token rather than an item number. For example, a coupon line has `ItemDescription01 = "/AAA BATTERY"` but the parent item on the same receipt is described as `"AA/AAA BATTERY"`. Neither item-number nor exact-description lookup succeeds, so the coupon was logged as an orphaned discount and silently dropped.

### Solution

`NetDiscounts` uses three matching strategies in order:
1. **Exact item-number match** — `/1553261` → item `1553261`
2. **Exact description match** (case-insensitive) — `/AAA BATTERY` → item `AAA BATTERY`
3. **Substring/contains match** (case-insensitive) — `/AAA BATTERY` → item `AA/AAA BATTERY` ✅ (new)

Returns the netted regular items and any orphaned discounts that could not be matched, so callers can log or handle them.

## Version Bump
- Type: PATCH (0.3.8 → 0.3.9)
- Reason: Bug fix + new exported utility function

## Checklist
- [x] Tests written before implementation (TDD red-green)
- [x] All tests passing (`go test ./pkg/costco -v -race`)
- [x] Version constant updated in `constants.go`
- [x] `CHANGELOG.md` updated
- [x] `README.md` badge updated
- [x] Code formatted with `go fmt`